### PR TITLE
Added popup for delete confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14918,6 +14918,11 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "sweetalert2": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.1.3.tgz",
+      "integrity": "sha512-vhUgY185mqfxTFCbJeTnAE2Oyo/IMQPPTnGgSjCABTOXbdEEcZKV0/P5bgzap4Z3VoJWozSH6AGfGhvwD7t+vg=="
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "3.4.3"
+    "react-scripts": "3.4.3",
+    "sweetalert2": "^11.1.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/comments/CommentsList.js
+++ b/src/components/comments/CommentsList.js
@@ -4,6 +4,7 @@ import { useHistory, useParams } from "react-router-dom"
 import { PostContext } from "../posts/PostProvider"
 import { CommentContext } from "../comments/CommentProvider"
 import { CommentForm } from "./CommentForm"
+import Swal from "sweetalert2"
 import "./Comments.css"
 
 
@@ -29,9 +30,30 @@ export const CommentList = () => {
     return b.created_on.localeCompare(a.created_on);
   });
 
-  const handleDelete = (commentId) => {
-    deleteComment(commentId).then(window.location.reload());
-  };
+  // const handleDelete = (commentId) => {
+  //   deleteComment(commentId).then(window.location.reload());
+  // };
+
+  const handleDeleteCard = (commentId) => {
+    Swal.fire({
+      title: "Are you sure?",
+      text: "You will not be able to undo!",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonText: "Yes, delete it!",
+      cancelButtonText: "Ah, cancel"
+    }).then((result) => {
+      if (result.isConfirmed) {
+        deleteComment(commentId).then(() => {
+          Swal.fire(
+            "Deleted!",
+            "Your comment has been deleted.",
+            "Success!"
+          ).then(getCommentsByPostId(parseInt(postId)))
+        })
+      }; 
+  })
+};
 
 
   return (
@@ -58,22 +80,14 @@ export const CommentList = () => {
                 <div>Date created: {comment.created_on}</div>
                 {comment.owner ? (
                   <div>
-                    <button
-                      className="comment-btn"
-                      onClick={() => {
-                        handleDelete(comment.id);
-                      }}
-                    >
-                      Delete
-                    </button>
-                    <button
-                      className="comment-btn"
-                      onClick={() => {
+                    <button onClick={() => 
+                      {handleDeleteCard(comment.id)}} className="button is-rounded remove">Delete
+                      <img className="trashIconPic" src="https://img.icons8.com/material/24/000000/trash--v1.png"/></button>
+                    {/* <button className="comment-btn" onClick={() => {
+                        handleDelete(comment.id)}}>Delete</button> */}
+                    <button className="comment-btn" onClick={() => {
                         history.push(`/comments/edit/${comment.id}`)
-                      }}
-                    >
-                      Edit
-                    </button>
+                      }}> Edit </button>
                   </div>
                 ) : (
                   <></>


### PR DESCRIPTION
Added a neat NPM package to replace JavaScript's popup boxes. Now when you click on delete for a comment you'll be presented with a delete confirmation or a cancel button.

Please install the npm package before trying to test
`npm install --save sweetalert2`

## Steps to test
1. run npm install
2. git fetch --all
3. checkout to anm-deletepopup and run server
4. go to view comments and click delete under one of them
5. verify the pop up box appears and you can click cancel to go back
6. verify clicking delete deletes comment with a confirmation and reloads the comment list